### PR TITLE
Add Plausible tracking for Marketing Links, Fix OG Images

### DIFF
--- a/app/(content)/docs/layout.tsx
+++ b/app/(content)/docs/layout.tsx
@@ -14,6 +14,7 @@ export default function DocsLayout({
       <Marketing
         className="dark:bg-secondary bg-sidebar"
         href="https://x.com/badtz_ui"
+        plausibleEvent="Clicked on Twitter"
       >
         Soon: New UI components daily! Follow us on X for updates.
       </Marketing>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,16 +10,17 @@ export const metadata: Metadata = {
   title: "BadtzUI • UI Components for React JS",
   description:
     "An expanding collection of 70+ free UI components. Production-grade animations with Framer Motion. Weekly updates. Open source. React, Tailwind, TypeScript & JavaScript.",
+  metadataBase: new URL("https://badtz-ui.com"),
   openGraph: {
     title: "BadtzUI - Modern React Components",
-    images: "/og-image.png",
+    images: [{ url: "/og-image.png", width: 1200, height: 630 }],
   },
   twitter: {
     card: "summary_large_image",
     title: "BadtzUI - UI Components for React JS",
     description:
       "An expanding collection of 70+ free UI components. Production-grade animations with Framer Motion. Weekly updates. Open source. React, Tailwind, TypeScript & JavaScript.",
-    images: "/twitter-image.png",
+    images: [{ url: "/twitter-image.png", width: 1200, height: 675 }],
     site: "@badtz_ui",
   },
 };

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -30,7 +30,7 @@ export default async function Home() {
     <>
       {/*
       //TODO: TESTS -> We're probably losing conversion rate, but the design is too ugly.
-      <Marketing href="https://pro.badtz-ui.com">
+      <Marketing href="https://pro.badtz-ui.com" plausibleEvent="Clicked on Pro">
         Coming Soon! Badtz UI Pro +70 expected templates, blocks, and much more!
       </Marketing>
       */}

--- a/components/marketing.tsx
+++ b/components/marketing.tsx
@@ -1,29 +1,43 @@
 "use client";
 
 import { cn } from "@/lib/utils";
+import { usePlausible } from "next-plausible";
 import Link from "next/link";
 
 interface MarketingProps {
   href: string;
   className?: string;
   children: React.ReactNode;
+  plausibleEvent?: string;
 }
 
 export default function Marketing({
   href,
   children,
   className,
+  plausibleEvent,
 }: MarketingProps) {
+  const plausible = usePlausible();
   return (
     <Link
       href={href}
       target="_blank"
       className={cn(
-        "bg-secondary dark:bg-secondary text-center relative px-4 py-1.5 w-full flex items-center justify-center border-b border-border",
+        "bg-secondary dark:bg-secondary text-center text-sm relative w-full flex items-center justify-center border-b border-border",
         className
       )}
     >
-      <span>{children}</span>
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+          if (plausibleEvent) {
+            plausible(plausibleEvent);
+          }
+        }}
+        className="h-full w-full px-4 py-1.5"
+      >
+        <span>{children}</span>
+      </button>
     </Link>
   );
 }


### PR DESCRIPTION
- Added Plausible tracking for Marketing links
- Introduced `plausibleEvent` prop to allow custom event tracking
- Fixed `onClick` issue by wrapping the event inside a `<button>` within the `<Link>`
- Ensured events are properly logged before navigation
- Fixed OG Images